### PR TITLE
add canonical link to discovery metadata

### DIFF
--- a/wis2node/metadata/discovery.py
+++ b/wis2node/metadata/discovery.py
@@ -60,6 +60,14 @@ class DiscoveryMetadata(BaseMetadata):
             'description': identifier,
             'function': 'collection'
         }
+        canonical_link = {
+            'url': f"{API_URL}/collections/discovery-metadata/{identifier}",
+            'type': 'OARec',
+            'name': identifier,
+            'description': identifier,
+            'function': 'canonical'
+        }
+
         md['distribution'] = {'oafeat': oafeat_link}
 
         LOGGER.debug('Generating OARec discovery metadata')
@@ -74,6 +82,16 @@ class DiscoveryMetadata(BaseMetadata):
             anytext_bag.extend(v['keywords']['en'])
 
         record['properties']['_metadata-anytext'] = ' '.join(anytext_bag)
+
+        LOGGER.debug('Adding canonical link')
+        canonical_link = {
+            'url': f"{API_URL}/collections/discovery-metadata/{identifier}",
+            'type': 'OARec',
+            'name': identifier,
+            'description': identifier,
+            'function': 'canonical'
+        }
+        record['links'].append(canonical_link)
 
         return json.dumps(record, default=json_serial, indent=4)
 

--- a/wis2node/metadata/discovery.py
+++ b/wis2node/metadata/discovery.py
@@ -60,14 +60,6 @@ class DiscoveryMetadata(BaseMetadata):
             'description': identifier,
             'function': 'collection'
         }
-        canonical_link = {
-            'url': f"{API_URL}/collections/discovery-metadata/{identifier}",
-            'type': 'OARec',
-            'name': identifier,
-            'description': identifier,
-            'function': 'canonical'
-        }
-
         md['distribution'] = {'oafeat': oafeat_link}
 
         LOGGER.debug('Generating OARec discovery metadata')


### PR DESCRIPTION
This PR adds a canonical link to wis2node discovery metadata.  This will help in keeping clear the authoritative source as per WIS 2.0 architecture.