### PR TITLE
improved Canadian "GISC" feed, initial dwd feed disabled.

### DIFF
--- a/docker/data-consumer/config/subscribe/gisc-ca.conf
+++ b/docker/data-consumer/config/subscribe/gisc-ca.conf
@@ -1,0 +1,54 @@
+# Simulation of what the feed from a GISC (or a WIS2 peer) might be like.
+# Using Canadian experimental feed as a stand-in.
+# if we have more than one GISC upstream, would insert a winnowing layer
+# to have downloads only occur from one GISC for any one product.
+
+broker amqps://anonymous:anonymous@hpfx.collab.science.gc.ca/
+exchange xs_pas037_wmosketch_public
+topic_prefix v03
+subtopic #
+
+#for development, want stuff to expire so you get a clean state.
+# 1 second/minute/hour/day/week 
+# once a configuration is stopped the broker will remember the pending
+# queue, until it expires.
+expire 1m
+
+instances 5
+#easier to view message flow one at a time.
+#batch 1
+
+mirror on
+
+# for debugging, control of log verbosity.
+logEvents post
+callback log
+
+# process a few messages, then exit.
+#message_count_max 5
+
+
+directory ${METPX_SR3_PATH_PUBLIC}/${BUPL}
+
+# reject 5 GB of .hdf data daily. not needed for demo.
+reject .*/IX.*KNES.*
+
+# reject other binary data that's too large for now... (but hundreds of MB's, not Gigs.)
+reject .*/HRS/.*
+reject .*/KWBC/Y[HOPQRTUV]/.*
+reject .*/KWBC/H[HOPRSTUV]/.*
+reject .*/KWBG/.*
+reject .*/model/.*
+reject .*/model-regional/.*
+reject .*/model-regional_KWBE/.*
+reject .*/pictorial/.*
+
+
+accept_unmatched on
+
+# local publishing.
+#instances 5
+post_broker  mqtt://${METPX_SR3_BROKER_USERNAME}:${METPX_SR3_BROKER_PASSWORD}@${METPX_SR3_HOST}/
+post_exchange xpublic
+post_baseUrl ${METPX_SR3_BASEURL}
+post_baseDir ${METPX_SR3_PATH_PUBLIC}

--- a/docker/data-consumer/config/subscribe/gisc-de.conf.off
+++ b/docker/data-consumer/config/subscribe/gisc-de.conf.off
@@ -1,0 +1,25 @@
+#
+# Sample prototype GISC feed from an experimental broker from Deutscher WetterDienst
+# for experimental use only by prior arrangement.
+#  Contact: Antje.Schremmer@dwd.de for credentials.
+#  to use with sarra, you need a line like so in credentials.conf:
+#    amqps://guest_canada:notReallyMyPassowrd@oflkd013.dwd.de login_method=PLAIN
+#  
+#  The login_method=PLAIN specification is necessary because for some reason auto-negotiation fails.
+#  replace guest_canada in the credentials file and the broker below by the user name assigned.
+# 
+broker amqps://guest_canada@oflkd013.dwd.de/
+
+acceptSizeWrong
+batch 1 
+#set sarracenia.moth.amqp.AMQP.logLevel debug
+#messageDebugDump
+
+reject .*/weather_reports/.*
+reject .*/webcam/.*
+
+strip 1 
+mirror
+directory ${METPX_SR3_PATH_PUBLIC}/${YYYYMMDD}T${HH}
+accept .*
+exchange wisof


### PR DESCRIPTION
The canadian feed was pulling in nwp model extracts from american regional model, as well as some local pictorial products.  It caused the feed to lag, also using only one process was not fast enough (serial downloads to slow) increased to 5.

A german feed is provided, but people need to request their own accounts. Description in the gisc-de.conf.off file itself.
