### PR TITLE
API: support daily indexes for datasets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+isodate
 pygeometa
 pyoscar
 PyYAML

--- a/wis2node/api/backend/elastic.py
+++ b/wis2node/api/backend/elastic.py
@@ -19,9 +19,11 @@
 #
 ###############################################################################
 
+from copy import deepcopy
 import logging
 
 from elasticsearch import Elasticsearch, helpers
+from isodate import parse_date
 
 from wis2node.api.backend.base import BaseBackend
 
@@ -89,12 +91,28 @@ class ElasticBackend(BaseBackend):
         """
 
         es_index = self.es_id(collection_id)
+        es_template = f'{es_index}.'
+
         if self.conn.indices.exists(es_index):
             msg = f'index {es_index} exists'
             LOGGER.error(msg)
             raise RuntimeError(msg)
 
-        self.conn.indices.create(index=es_index, body=SETTINGS)
+        if self.conn.indices.exists_template(es_template):
+            msg = f'template {es_template} exists'
+            LOGGER.error(msg)
+            raise RuntimeError(msg)
+
+        settings = deepcopy(SETTINGS)
+
+        if self.is_dataset(es_index):
+            LOGGER.debug('dataset index detected')
+            settings['index_patterns'] = [f'{es_template}*']
+            settings['order'] = 0
+            settings['version'] = 1
+            self.conn.indices.put_template(es_template, settings)
+
+        self.conn.indices.create(index=es_index, body=settings)
 
         scheme = 'https' if self.port == 443 else 'http'
         return {
@@ -114,12 +132,17 @@ class ElasticBackend(BaseBackend):
         """
 
         es_index = self.es_id(collection_id)
+        es_template = f'{es_index}.'
+
         if not self.conn.indices.exists(es_index):
             msg = f'index {es_index} does not exist'
             LOGGER.error(msg)
             raise RuntimeError(msg)
 
         self.conn.indices.delete(index=es_index)
+
+        if self.conn.indices.exists_template(es_template):
+            self.conn.indices.delete_template(es_template)
 
     def upsert_collection_items(self, collection_id: str, items: list) -> str:
         """
@@ -133,7 +156,8 @@ class ElasticBackend(BaseBackend):
 
         es_index = self.es_id(collection_id)
 
-        if not self.conn.indices.exists(es_index):
+        if (not self.is_dataset(es_index) and
+                not self.conn.indices.exists(es_index)):
             LOGGER.debug('Index {es_index} does not exist.  Creating')
             self.add_collection(es_index)
 
@@ -143,11 +167,16 @@ class ElasticBackend(BaseBackend):
             """
 
             for feature in features:
-                feature["properties"]["id"] = feature["id"]
+                es_index2 = es_index
+                feature['properties']['id'] = feature['id']
+                if self.is_dataset(collection_id):
+                    LOGGER.debug('Determinining index date from OM GeoJSON')
+                    date_ = parse_date(feature['properties']['phenomenonTime'])
+                    es_index2 = f"{es_index}.{date_.strftime('%Y-%m-%d')}"
                 yield {
-                    "_index": es_index,
-                    "_id": feature['id'],
-                    "_source": feature
+                    '_index': es_index2,
+                    '_id': feature['id'],
+                    '_source': feature
                 }
 
         helpers.bulk(self.conn, gendata(items))
@@ -163,6 +192,18 @@ class ElasticBackend(BaseBackend):
         """
 
         raise NotImplementedError()
+
+    def is_dataset(self, collection_id):
+        """
+        Check whether the index is a dataset (and thus
+        needs daily index management)
+
+        :param collection_id: name of collection
+
+        :returns: `bool` of evaluation
+        """
+
+        return '.' in collection_id
 
     def __repr__(self):
         return f'<BaseBackend> (host={self.host}, port={self.port})'

--- a/wis2node/api/backend/elastic.py
+++ b/wis2node/api/backend/elastic.py
@@ -107,12 +107,15 @@ class ElasticBackend(BaseBackend):
 
         if self.is_dataset(es_index):
             LOGGER.debug('dataset index detected')
+            LOGGER.debug('creating index template')
             settings['index_patterns'] = [f'{es_template}*']
             settings['order'] = 0
             settings['version'] = 1
             self.conn.indices.put_template(es_template, settings)
 
-        self.conn.indices.create(index=es_index, body=settings)
+        else:
+            LOGGER.debug('metadata index detected')
+            self.conn.indices.create(index=es_index, body=settings)
 
         scheme = 'https' if self.port == 443 else 'http'
         return {

--- a/wis2node/api/config/pygeoapi.py
+++ b/wis2node/api/config/pygeoapi.py
@@ -77,7 +77,7 @@ class PygeoapiConfig(BaseConfig):
             'providers': [{
                 'type': type_,
                 'name': provider_name,
-                'data': f"http://{API_BACKEND_HOST}:{API_BACKEND_PORT}/{meta.get('id')}",  # noqa
+                'data': f"http://{API_BACKEND_HOST}:{API_BACKEND_PORT}/{meta.get('id')}.*",  # noqa
                 'id_field': meta.get('id_field'),
                 'time_field': meta.get('time_field'),
                 'title_field': meta.get('title_field')


### PR DESCRIPTION
This PR updates the API backend to support daily indexes for datasets.  The idea here is to create indexes based on their YYYY-MM-DD:

- `observations-surface-land.mw.fwcl.landfixed.2021-07-07`
- `observations-surface-land.mw.fwcl.landfixed.2021-07-08`
- ...

ES Index access from pygeoapi then becomes `http://localhost:9200/observations-surface-land.mw.fwcl.landfixed.*/_search`.

The benefit is also being able to delete entire daily indexes based on date (retention) easily and efficiently.

Metadata (discovery, station) indexes are unaffected.

This also puts a hard link to the incoming dataset's GeoJSON file to have a `properties.phenomenonTime` as per the OM GeoJSON (cc @david-i-berry).  So part of any wis2node plugin setup will require that GeoJSON emitted has this property (need standardized OM GeoJSON).